### PR TITLE
Updated handling for 8.9.1 on Ubuntu

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -220,7 +220,8 @@ fn is_vulnerable(version: &str) -> bool {
                     && ssh_minor == 9
                     && ssh_patch >= 1
                     && upstream_patch >= 3
-                    && ubuntu_patch >= 10)
+                    && ubuntu_patch >= 0
+                    && ubuntu_subpatch >= 10)
                     || (ssh_major == 9
                         && ssh_minor == 3
                         && ssh_patch >= 1


### PR DESCRIPTION
Suspect there's an issue where the initially used "ubuntu_patch >= 10" should have been "ubuntu_subpatch >=10". 

Based on the formatting of a "correct" version name that was failing the check - OpenSSH_8.9p1 Ubuntu-3ubuntu0.10